### PR TITLE
14 limit switches

### DIFF
--- a/Arm/Arm.ino
+++ b/Arm/Arm.ino
@@ -11,15 +11,15 @@
 // Pinouts
 #define SWIVEL_EN_PIN 35
 #define SWIVEL_CS_PIN 10
-#define SWIVEL_LS_PIN 42
+#define SWIVEL_LS_PIN 7
 
 #define EXTEND_EN_PIN 40 // 34
 #define EXTEND_CS_PIN 36 // 37
-#define EXTEND_LS_PIN 43
+#define EXTEND_LS_PIN 8
 
 #define LIFT_EN_PIN 34 // 40
 #define LIFT_CS_PIN 37 // 36
-#define LIFT_LS_PIN 45
+#define LIFT_LS_PIN 9
 
 // Limits for the joints, in terms of radians from their limit switches
 #define SWIVEL_MIN -2 * PI  // INFINITY // can swivel in endless circles

--- a/Arm/Arm.ino
+++ b/Arm/Arm.ino
@@ -11,12 +11,15 @@
 // Pinouts
 #define SWIVEL_EN_PIN 35
 #define SWIVEL_CS_PIN 10
+#define SWIVEL_LS_PIN 42
 
 #define EXTEND_EN_PIN 40 // 34
 #define EXTEND_CS_PIN 36 // 37
+#define EXTEND_LS_PIN 43
 
 #define LIFT_EN_PIN 34 // 40
 #define LIFT_CS_PIN 37 // 36
+#define LIFT_LS_PIN 45
 
 // Limits for the joints, in terms of radians from their limit switches
 #define SWIVEL_MIN -2 * PI  // INFINITY // can swivel in endless circles
@@ -55,9 +58,9 @@
 */ 
 double gripperX = 0, gripperY = 0, gripperZ = 0;
 
-StepperMotor swivel = StepperMotor(SWIVEL_CS_PIN, SWIVEL_EN_PIN, MOTOR_CURRENT, SWIVEL_MIN, SWIVEL_MAX, SWIVEL_GEARBOX);
-StepperMotor extend = StepperMotor(EXTEND_CS_PIN, EXTEND_EN_PIN, MOTOR_CURRENT, EXTEND_MIN, EXTEND_MAX, EXTEND_GEARBOX);
-StepperMotor lift = StepperMotor(LIFT_CS_PIN, LIFT_EN_PIN, MOTOR_CURRENT, LIFT_MIN, LIFT_MAX, LIFT_GEARBOX);
+StepperMotor swivel = StepperMotor(SWIVEL_CS_PIN, SWIVEL_EN_PIN, SWIVEL_LS_PIN, MOTOR_CURRENT, SWIVEL_MIN, SWIVEL_MAX, SWIVEL_GEARBOX);
+StepperMotor extend = StepperMotor(EXTEND_CS_PIN, EXTEND_EN_PIN, EXTEND_LS_PIN, MOTOR_CURRENT, EXTEND_MIN, EXTEND_MAX, EXTEND_GEARBOX);
+StepperMotor lift = StepperMotor(LIFT_CS_PIN, LIFT_EN_PIN, LIFT_LS_PIN, MOTOR_CURRENT, LIFT_MIN, LIFT_MAX, LIFT_GEARBOX);
 
 void setup() {
 	pinMode(SWIVEL_CS_PIN, OUTPUT);

--- a/Gripper/Gripper.ino
+++ b/Gripper/Gripper.ino
@@ -5,12 +5,17 @@
 // Pinouts
 #define ROTATE_EN_PIN 35
 #define ROTATE_CS_PIN 10
+#define ROTATE_LS_PIN 7
+
 
 #define LIFT_EN_PIN 34
 #define LIFT_CS_PIN 37
+#define LIFT_LS_PIN 8
+
 
 #define PINCH_EN_PIN 40
 #define PINCH_CS_PIN 36
+#define PINCH_LS_PIN 9
 
 #define ROTATE_MIN -2 * PI
 #define ROTATE_MAX 2 * PI
@@ -38,9 +43,9 @@
 #define HIGH_CURRENT 2200
 
 
-StepperMotor rotate = StepperMotor(ROTATE_CS_PIN, ROTATE_EN_PIN, LOW_CURRENT, ROTATE_MIN, ROTATE_MAX, 99.51);
-StepperMotor pinch = StepperMotor(PINCH_CS_PIN, PINCH_EN_PIN, LOW_CURRENT, PINCH_MIN, PINCH_MAX, 199.02);
-StepperMotor lift = StepperMotor(LIFT_CS_PIN, LIFT_EN_PIN, HIGH_CURRENT, LIFT_MIN, LIFT_MAX, 29.16);
+StepperMotor rotate = StepperMotor(ROTATE_CS_PIN, ROTATE_EN_PIN, ROTATE_LS_PIN, LOW_CURRENT, ROTATE_MIN, ROTATE_MAX, 99.51);
+StepperMotor pinch = StepperMotor(PINCH_CS_PIN, PINCH_EN_PIN, PINCH_LS_PIN, LOW_CURRENT, PINCH_MIN, PINCH_MAX, 199.02);
+StepperMotor lift = StepperMotor(LIFT_CS_PIN, LIFT_EN_PIN, LIFT_LS_PIN, HIGH_CURRENT, LIFT_MIN, LIFT_MAX, 29.16);
 
 void setup() { 
 	Serial.begin(9600);

--- a/libraries/BURT_arm_motor/src/BURT_arm_motor.cpp
+++ b/libraries/BURT_arm_motor/src/BURT_arm_motor.cpp
@@ -68,12 +68,10 @@ void StepperMotor::setup() {
 	nextStallCheck = millis() + STALL_CHECK_INTERVAL;
 }
 
-// TODO: Make this calibrate. 
-// See https://github.com/BinghamtonRover/arm-firmware/issues/7
 void StepperMotor::calibrate() { 
-	driver.XACTUAL(radToSteps(maxLimit));
-	angle = maxLimit;
-	Serial.println("Hm, try now");
+	while(!readLimitSwitch()) moveBy(PI/180);
+	angle = 0;
+	Serial.println("StepperMotor calibrated.");
 }
 
 bool StepperMotor::isFinished() { return driver.XTARGET() == driver.XACTUAL(); }
@@ -116,6 +114,10 @@ void StepperMotor::moveBy(float radians) {
 
 void StepperMotor::debugMoveSteps(int steps) {
 	driver.XTARGET(steps);
+}
+
+bool StepperMotor::readLimitSwitch() {
+	return digitalRead(limitSwitchPin)==HIGH;
 }
 
 // The following close bracket marks the file for Doxygen

--- a/libraries/BURT_arm_motor/src/BURT_arm_motor.cpp
+++ b/libraries/BURT_arm_motor/src/BURT_arm_motor.cpp
@@ -23,6 +23,7 @@ void StepperMotor::setup() {
 	// -->
 	pinMode(enablePin, OUTPUT);
 	pinMode(chipSelectPin, OUTPUT);
+	pinMode(limitSwitchPin,INPUT_PULLUP);
 	digitalWrite(chipSelectPin, HIGH);
 	digitalWrite(enablePin, LOW);
 	// <--
@@ -117,7 +118,7 @@ void StepperMotor::debugMoveSteps(int steps) {
 }
 
 bool StepperMotor::readLimitSwitch() {
-	return digitalRead(limitSwitchPin)==HIGH;
+	return digitalRead(limitSwitchPin)==LOW;
 }
 
 // The following close bracket marks the file for Doxygen

--- a/libraries/BURT_arm_motor/src/BURT_arm_motor.cpp
+++ b/libraries/BURT_arm_motor/src/BURT_arm_motor.cpp
@@ -70,8 +70,9 @@ void StepperMotor::setup() {
 }
 
 void StepperMotor::calibrate() { 
-	while(!readLimitSwitch()) moveBy(PI/180);
-	angle = 0;
+	while(!readLimitSwitch()) moveBy(-PI/180);
+	driver.XACTUAL(radToSteps(minLimit));
+	angle = minLimit;
 	Serial.println("StepperMotor calibrated.");
 }
 

--- a/libraries/BURT_arm_motor/src/BURT_arm_motor.h
+++ b/libraries/BURT_arm_motor/src/BURT_arm_motor.h
@@ -165,7 +165,7 @@ class StepperMotor {
 
 		/// Checks if the limit switch is activated.
 		///
-		/// Assumes HIGH is active.
+		/// Assumes LOW is active since it is declared an INPUT_PULLUP in setup.
 		bool readLimitSwitch();
 };
 

--- a/libraries/BURT_arm_motor/src/BURT_arm_motor.h
+++ b/libraries/BURT_arm_motor/src/BURT_arm_motor.h
@@ -46,6 +46,11 @@ class StepperMotor {
 		/// Enables the motor. This doesn't seem to be used outside of #setup, not even by TMC. 
 		byte enablePin;
 
+		/// The limit switch pin.
+		/// 
+		/// Used to evaluate whether the motor has trigged the limit switch. Used for calibration.
+		byte limitSwitchPin;
+
 		/// The Root Mean Square current to feed the motor. 
 		/// 
 		/// This value is passed to TMC in #setup.
@@ -99,9 +104,10 @@ class StepperMotor {
 		float angle;
 
 		/// Manage a stepper motor with the given pins.
-		StepperMotor(byte chipSelectPin, byte enablePin, int current, float minLimit, float maxLimit, float gearboxRatio) : 
+		StepperMotor(byte chipSelectPin, byte enablePin, byte limitSwitchPin, int current, float minLimit, float maxLimit, float gearboxRatio) : 
 			chipSelectPin(chipSelectPin),
 			enablePin(enablePin),
+			limitSwitchPin(limitSwitchPin),
 			current(current),
 			minLimit(minLimit),
 			maxLimit(maxLimit),
@@ -123,8 +129,6 @@ class StepperMotor {
 		/// 
 		/// Moves backwards until it hits its limit switch, then stops and overrides its internal
 		/// state (including #angle) to a known value.
-		/// 
-		/// NOTE: This function does not currently move. For now, it just resets the state.
 		void calibrate();  // calibrates the motor
 
 		/// Whether the motor has reached its destination.
@@ -158,6 +162,11 @@ class StepperMotor {
 		/// Use in debugging only. In production code, use #moveBy. This method can help determine
 		/// when the conversion factor (#radToSteps) is off, or the motor is misbehaving.
 		void debugMoveSteps(int steps);
+
+		/// Checks if the limit switch is activated.
+		///
+		/// Assumes HIGH is active.
+		bool readLimitSwitch();
 };
 
 #endif


### PR DESCRIPTION
closes #7 
closes #14 

I updated the calibration function to use the newly created `readLimitSwitch()` method of stepper motors to calibrate properly.

I added placeholder limit switch pin constants in `Arm.ino`, then used those inside each stepper motor constructor. 